### PR TITLE
Sanitise go enum names

### DIFF
--- a/clientgen/util.go
+++ b/clientgen/util.go
@@ -1,0 +1,9 @@
+package clientgen
+
+import "regexp"
+
+// SanitiseVariableName removes special characters from strings intended to be used as variables
+func SanitiseVariableName(input string) string {
+	regex := regexp.MustCompile("[^a-zA-Z0-9]+")
+	return regex.ReplaceAllString(input, "")
+}

--- a/clientgen/util_test.go
+++ b/clientgen/util_test.go
@@ -1,0 +1,31 @@
+package clientgen
+
+import "testing"
+
+func TestSanitiseVariableName(t *testing.T) {
+	tcs := []struct {
+		name      string
+		input     string
+		expOutput string
+	}{
+		{
+			name:      "no change",
+			input:     "HelloWorld123",
+			expOutput: "HelloWorld123",
+		},
+		{
+			name:      "illegal characters",
+			input:     "Hello/Wor)l!d_1&2*3@",
+			expOutput: "HelloWorld123",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			output := SanitiseVariableName(tc.input)
+			if tc.expOutput != output {
+				t.Fatalf("output %s didn't match expected output %s", output, tc.expOutput)
+			}
+		})
+	}
+}

--- a/golang/golang.go
+++ b/golang/golang.go
@@ -134,5 +134,5 @@ func typename(t clientgen.Type) string {
 }
 
 func enumvalue(t, v string) string {
-	return t + strings.Title(strings.ToLower(v))
+	return t + strings.Title(strings.ToLower(clientgen.SanitiseVariableName(v)))
 }


### PR DESCRIPTION
The Luno-API has an enum of which one of the values contains a character that would be illegal in a golang variable name. Sanitise the variable names by removing characters 