### PR TITLE
Exclude underscore from characters being sanitised

### DIFF
--- a/clientgen/util.go
+++ b/clientgen/util.go
@@ -4,6 +4,6 @@ import "regexp"
 
 // SanitiseVariableName removes special characters from strings intended to be used as variables
 func SanitiseVariableName(input string) string {
-	regex := regexp.MustCompile("[^a-zA-Z0-9]+")
+	regex := regexp.MustCompile("[^a-zA-Z0-9_]+")
 	return regex.ReplaceAllString(input, "")
 }

--- a/clientgen/util_test.go
+++ b/clientgen/util_test.go
@@ -10,13 +10,13 @@ func TestSanitiseVariableName(t *testing.T) {
 	}{
 		{
 			name:      "no change",
-			input:     "HelloWorld123",
-			expOutput: "HelloWorld123",
+			input:     "Hello_World123",
+			expOutput: "Hello_World123",
 		},
 		{
 			name:      "illegal characters",
-			input:     "Hello/Wor)l!d_1&2*3@",
-			expOutput: "HelloWorld123",
+			input:     "Hello_/Wor)l!d1&2*3@",
+			expOutput: "Hello_World123",
 		},
 	}
 


### PR DESCRIPTION
Underscores are not a problem when generating go code. Exclude them from being sanitised.