### PR TITLE
Use Time struct for integer timestamps

### DIFF
--- a/clientgen/convert.go
+++ b/clientgen/convert.go
@@ -275,7 +275,7 @@ func convertType(spec *openapi.Swagger, api *API, p *simpleSchema,
 			return
 		}
 
-		if p.Type[0] == "string" && p.Format == "timestamp" {
+		if (p.Type[0] == "string" || p.Type[0] == "integer") && p.Format == "timestamp" {
 			typ.Kind = KindTimestamp
 			return
 		}

--- a/clientgen/convert_test.go
+++ b/clientgen/convert_test.go
@@ -1,0 +1,108 @@
+package clientgen
+
+import (
+	"encoding/json"
+	openapi "github.com/go-openapi/spec"
+	"github.com/google/go-cmp/cmp"
+	"github.com/luno/sdkgen/clientgen/testspecs"
+	"testing"
+)
+
+func TestConvertSpec(t *testing.T) {
+	tcs := []struct {
+		name      string
+		inputSpec string
+		expAPI    API
+	}{
+		{
+			name:      "standard spec",
+			inputSpec: testspecs.TestSpec,
+			expAPI: API{
+				Description: "Spec to test conversion",
+				Sections: []Section{
+					{
+						Name:        "Test1",
+						Description: "Test1 Endpoint",
+						Endpoints: []Endpoint{
+							{
+								Method:      "POST",
+								Path:        "/test1",
+								Name:        "Test1",
+								Description: []string{"Test1 endpoint"},
+								Request: Type{
+									Kind: KindStruct,
+									Name: "Test1Request",
+									StructProps: &StructProps{
+										Properties: []Property{
+											{
+												Name:        "field1",
+												Description: []string{"Field1 of test endpoint"},
+												Type: Type{
+													Kind: KindString,
+												},
+												Example:  "Field1 Example",
+												Required: true,
+											},
+											{
+												Name:        "field2",
+												Description: []string{"Field2 of test endpoint"},
+												Type: Type{
+													Kind: KindInteger,
+												},
+												Example: "Field2 Example",
+											},
+										},
+									},
+								},
+								Response: Type{
+									Kind: KindStruct,
+									Name: "Test1Response",
+									StructProps: &StructProps{
+										[]Property{
+											{
+												Name:        "field1",
+												Description: []string{"field1 desc"},
+												Type: Type{
+													Kind: KindDecimal,
+												},
+											},
+											{
+												Name:        "field2",
+												Description: []string{"Unix timestamp in milliseconds"},
+												Type: Type{
+													Kind: KindTimestamp,
+												},
+											},
+											{
+												Name:        "field3",
+												Description: []string{"Unix timestamp in milliseconds string"},
+												Type: Type{
+													Kind: KindTimestamp,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			var spec *openapi.Swagger
+			if err := json.Unmarshal([]byte(tc.inputSpec), &spec); err != nil {
+				t.Errorf("unmarshal failed: %s", err)
+			}
+
+			api := ConvertSpec(spec)
+
+			if !cmp.Equal(tc.expAPI, api) {
+				t.Errorf("expected api differs:\n%s", cmp.Diff(tc.expAPI, api))
+			}
+		})
+	}
+}

--- a/clientgen/testspecs/import.go
+++ b/clientgen/testspecs/import.go
@@ -1,0 +1,6 @@
+package testspecs
+
+import _ "embed"
+
+//go:embed test_spec.json
+var TestSpec string

--- a/clientgen/testspecs/test_spec.json
+++ b/clientgen/testspecs/test_spec.json
@@ -1,0 +1,89 @@
+{
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "schemes": [
+    "https"
+  ],
+  "swagger": "2.0",
+  "info": {
+    "description": "Spec to test conversion",
+    "title": "Test API",
+    "version": "1.0.0"
+  },
+  "host": "api.test.com",
+  "paths": {
+    "/test1": {
+      "post": {
+        "description": "Test1 endpoint",
+        "tags": [
+          "Test1"
+        ],
+        "summary": "Test1 endpoint generation test",
+        "operationId": "Test1",
+        "parameters": [
+          {
+            "type": "string",
+            "example": "Field1 Example",
+            "x-go-name": "Field1Go",
+            "description": "Field1 of test endpoint",
+            "name": "field1",
+            "in": "query",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "example": "Field2 Example",
+            "x-go-name": "Field2Go",
+            "description": "Field2 of test endpoint",
+            "name": "field2",
+            "in": "query",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Test1Response"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Test1Response": {
+      "type": "object",
+      "properties": {
+        "field1": {
+          "description": "field1 desc",
+          "type": "string",
+          "format": "amount",
+          "x-go-name": "field1go"
+        },
+        "field2": {
+          "description": "Unix timestamp in milliseconds",
+          "type": "integer",
+          "format": "timestamp",
+          "x-go-name": "field2go"
+        },
+        "field3": {
+          "description": "Unix timestamp in milliseconds string",
+          "type": "string",
+          "format": "timestamp",
+          "x-go-name": "field3go"
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "description": "Test1 Endpoint",
+      "name": "Test1"
+    }
+  ]
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/go-openapi/spec v0.20.3
+	github.com/google/go-cmp v0.2.0
 	github.com/luno/jettison v0.0.0-20210526084548-7f4f94692e7a
 	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135
 )

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.16
 require (
 	github.com/go-openapi/spec v0.20.3
 	github.com/luno/jettison v0.0.0-20210526084548-7f4f94692e7a
+	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135
 )

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,7 @@ golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181127232545-e782529d0ddd/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 h1:5Beo0mZN8dRzgrMMkDp0jc8YXQKx9DiJ2k1dkvGsn5A=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,7 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/pprof v0.0.0-20181127221834-b4f47329b966/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=


### PR DESCRIPTION
Recently Luno corrected the documentation by changing the type of timestamp fields from string to integer. The caused sdkgen to no longer use the Time struct for these fields. Fixed the issue. 
Also rather use the imports package to perform goimports instead of the cli.