### PR TITLE
ci: test latest Go only and bump go.mod to 1.26.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,23 +5,20 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    
+
 jobs:
 
   build:
-    strategy:
-      matrix:
-        go: ['1.24', '1']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ matrix.go }}
-        
+        go-version: '1'
+
     - name: Build
       run: go build -v ./...
-      
+
     - name: Test
       run: go test ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1'
+        go-version-file: 'go.mod'
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/sdkgen
 
-go 1.25.3
+go 1.26.0
 
 require (
 	github.com/go-openapi/spec v0.22.3


### PR DESCRIPTION
Simplify the CI test matrix to only test with the latest Go (`'1'`), and bump the `go` directive in `go.mod` to `1.26.0`.

Testing multiple Go versions caused flaky failures whenever we bumped deps ahead of the oldest supported version. Since we don't commit to long-term compatibility with older Go releases, there's no value in the matrix.