### PR TITLE
Resolve scalar-typed named refs inline

### DIFF
--- a/clientgen/convert.go
+++ b/clientgen/convert.go
@@ -312,6 +312,15 @@ func convertType(spec *openapi.Swagger, api *API, p *simpleSchema,
 		return
 	}
 
+	// If the referenced definition is a primitive (e.g., a named alias like
+	// DecimalFloat which is `{type: "string", format: "amount"}`), convert it
+	// as if the schema were inlined rather than emitting an empty named
+	// struct. Without this, named scalar aliases generate `type Foo struct{}`
+	// and silently discard their values when JSON-unmarshaled.
+	if len(schema.Type) > 0 && schema.Type[0] != "object" {
+		return convertType(spec, api, schemaToSimpleSchema(*schema), seen)
+	}
+
 	typ.Kind = KindStruct
 	typ.Name = name
 

--- a/clientgen/convert_test.go
+++ b/clientgen/convert_test.go
@@ -80,6 +80,13 @@ func TestConvertSpec(t *testing.T) {
 													Kind: KindTimestamp,
 												},
 											},
+											{
+												Name:        "field4",
+												Description: []string{"Amount via named scalar alias"},
+												Type: Type{
+													Kind: KindDecimal,
+												},
+											},
 										},
 									},
 								},

--- a/clientgen/testspecs/test_spec.json
+++ b/clientgen/testspecs/test_spec.json
@@ -76,8 +76,18 @@
           "type": "string",
           "format": "timestamp",
           "x-go-name": "field3go"
+        },
+        "field4": {
+          "description": "Amount via named scalar alias",
+          "$ref": "#/definitions/NamedDecimal"
         }
       }
+    },
+    "NamedDecimal": {
+      "description": "Named scalar alias for an amount value",
+      "type": "string",
+      "format": "amount",
+      "x-go-package": "luno/example"
     }
   },
   "tags": [


### PR DESCRIPTION
## Summary
- When a property `\$ref`s a named definition whose resolved schema is a primitive (e.g. `DecimalFloat: {type: \"string\", format: \"amount\"}`), `convertType` previously emitted a named empty struct, because the ref-handling branch unconditionally set `KindStruct` and then iterated over the resolved schema's (empty) `Properties`.
- Downstream effect: SDKs ended up with `type DecimalFloat struct{}`. Any incoming JSON value for fields of that type was silently discarded on unmarshal, e.g. `Transaction.Available`/`Balance` returned zero values in luno-go.
- Fix: after resolving the ref, if the resolved schema has a non-object primitive type, recurse with the resolved schema so it maps to the appropriate `Kind` (Decimal, Timestamp, String, ...) just as if it had been declared inline.
- Added a `field4` to the existing test spec that `\$ref`s a named `{type: \"string\", format: \"amount\"}` definition, asserting it converts to `KindDecimal`.

## Verified end-to-end
Rebuilt sdkgen against the public API swagger spec and regenerated luno-go's `types.go` — `Transaction.{Available, AvailableDelta, Balance, BalanceDelta}` now generate as `decimal.Decimal` directly, with no `DecimalFloat` named type emitted.

## Related
- luno/luno-go#192 had to manually revert those four fields post-regen; once this lands, that manual fix-up is no longer needed on the next regeneration.

## Test plan
- [x] `go test ./...` passes (existing standard-spec test extended with named scalar alias case)
- [x] End-to-end: regenerated luno-go against the live publicapi swagger spec produces correct `decimal.Decimal` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)